### PR TITLE
Fixing a typo in the python API: 'int' should be 'int64'

### DIFF
--- a/hyperclient/python/hyperclient.pyx
+++ b/hyperclient/python/hyperclient.pyx
@@ -227,7 +227,7 @@ cdef _obj_to_backing(v):
         mixedtype = TypeError("Cannot store heterogeneous maps")
         for x, y in v.iteritems():
             if isinstance(x, int):
-                if keytype not in ('int', None):
+                if keytype not in ('int64', None):
                     raise mixedtype
                 backing += struct.pack('<q', x)
                 keytype = 'int64'
@@ -240,7 +240,7 @@ cdef _obj_to_backing(v):
             else:
                 raise mixedtype
             if isinstance(y, int):
-                if valtype not in ('int', None):
+                if valtype not in ('int64', None):
                     raise mixedtype
                 backing += struct.pack('<q', y)
                 valtype = 'int64'


### PR DESCRIPTION
This caused the python API to incorrectly raise the exception:

TypeError: Cannot store heterogeneous maps

when one tries to put() a map attribute with key and/or value being
of type 'int64' and the map contains > 1 entries.
