### PR TITLE
Removed a leftover debugging println() in SearchBase.java

### DIFF
--- a/hyperclient/java/extra_src/SearchBase.java
+++ b/hyperclient/java/extra_src/SearchBase.java
@@ -107,7 +107,6 @@ public class SearchBase extends Pending
         while ( ! finished && backlogged.size() == 0 )
         {
             client.loop();
-            System.out.println("next(): status = " + status());
         }
 
         if ( backlogged.size() > 0 )


### PR DESCRIPTION
No one would have seen it unless they called the **next()** method of SearchBase without calling **hasNext()**

This commit will allow users to call **next()** without seeing debug garbage.
