### PR TITLE
Made java bindings work in OSX

### DIFF
--- a/client/java/extra_src/DeferredCount.java
+++ b/client/java/extra_src/DeferredCount.java
@@ -32,7 +32,7 @@ public class DeferredCount extends Deferred
             chks = (hyperclient_attribute_check)(retvals.get(0));
             chks_sz = ((Long)(retvals.get(1))).longValue();
 
-            res_ptr = hyperclient.new_uint64_t_ptr();
+            res_ptr = hyperclient_lc.new_uint64_t_ptr();
 
             reqId = client.count(client.getBytes(space,true),
                                  chks, chks_sz,
@@ -55,7 +55,7 @@ public class DeferredCount extends Deferred
 
         if (status() == hyperclient_returncode.HYPERCLIENT_SUCCESS || unsafe == 0)
         {
-            return hyperclient.uint64_t_ptr_value(res_ptr);
+            return hyperclient_lc.uint64_t_ptr_value(res_ptr);
         }
         else
         {
@@ -67,6 +67,6 @@ public class DeferredCount extends Deferred
     {
         super.finalize();
 
-        if (res_ptr != null) hyperclient.delete_uint64_t_ptr(res_ptr);
+        if (res_ptr != null) hyperclient_lc.delete_uint64_t_ptr(res_ptr);
     }
 }

--- a/client/java/extra_src/DeferredGet.java
+++ b/client/java/extra_src/DeferredGet.java
@@ -13,8 +13,8 @@ public class DeferredGet extends Deferred
     {
         super(client);
 
-        attrs_ptr = hyperclient.new_hyperclient_attribute_ptr();
-        attrs_sz_ptr = hyperclient.new_size_t_ptr();
+        attrs_ptr = hyperclient_lc.new_hyperclient_attribute_ptr();
+        attrs_sz_ptr = hyperclient_lc.new_size_t_ptr();
 
         reqId = client.get(client.getBytes(space,true),
                            client.getBytes(key),
@@ -33,8 +33,8 @@ public class DeferredGet extends Deferred
         if (status() == hyperclient_returncode.HYPERCLIENT_SUCCESS)
         {
             hyperclient_attribute attrs
-                = hyperclient.hyperclient_attribute_ptr_value(attrs_ptr);
-            long attrs_sz = hyperclient.size_t_ptr_value(attrs_sz_ptr);
+                = hyperclient_lc.hyperclient_attribute_ptr_value(attrs_ptr);
+            long attrs_sz = hyperclient_lc.size_t_ptr_value(attrs_sz_ptr);
 
             Map map = null;
 
@@ -45,7 +45,7 @@ public class DeferredGet extends Deferred
             finally
             {
                 if ( attrs != null )
-                    hyperclient.hyperclient_destroy_attrs(attrs,attrs_sz);
+                    hyperclient_lc.hyperclient_destroy_attrs(attrs,attrs_sz);
             }
 
             return map;
@@ -64,7 +64,7 @@ public class DeferredGet extends Deferred
     {
         super.finalize();
 
-        if (attrs_ptr != null) hyperclient.delete_hyperclient_attribute_ptr(attrs_ptr);
-        if (attrs_sz_ptr != null) hyperclient.delete_size_t_ptr(attrs_sz_ptr);
+        if (attrs_ptr != null) hyperclient_lc.delete_hyperclient_attribute_ptr(attrs_ptr);
+        if (attrs_sz_ptr != null) hyperclient_lc.delete_size_t_ptr(attrs_sz_ptr);
     }
 }

--- a/client/java/extra_src/Pending.java
+++ b/client/java/extra_src/Pending.java
@@ -14,8 +14,8 @@ public class Pending
     public Pending(HyperClient client)
     {
         this.client = client;
-        rc_ptr = hyperclient.new_rc_ptr();
-        hyperclient.rc_ptr_assign(rc_ptr,hyperclient_returncode.HYPERCLIENT_GARBAGE);
+        rc_ptr = hyperclient_lc.new_rc_ptr();
+        hyperclient_lc.rc_ptr_assign(rc_ptr,hyperclient_returncode.HYPERCLIENT_GARBAGE);
     }
 
     public void callback()
@@ -26,14 +26,14 @@ public class Pending
 
     public hyperclient_returncode status()
     {
-        return hyperclient.rc_ptr_value(rc_ptr);
+        return hyperclient_lc.rc_ptr_value(rc_ptr);
     }
 
     protected void finalize() throws Throwable
     {
         super.finalize();
 
-        hyperclient.delete_rc_ptr(rc_ptr);
+        hyperclient_lc.delete_rc_ptr(rc_ptr);
     }
 
     protected void checkReqId(long reqId, hyperclient_returncode status)

--- a/client/java/extra_src/SearchBase.java
+++ b/client/java/extra_src/SearchBase.java
@@ -16,8 +16,8 @@ public class SearchBase extends Pending
     {
         super(client);
 
-        attrs_ptr = hyperclient.new_hyperclient_attribute_ptr();
-        attrs_sz_ptr = hyperclient.new_size_t_ptr();
+        attrs_ptr = hyperclient_lc.new_hyperclient_attribute_ptr();
+        attrs_sz_ptr = hyperclient_lc.new_size_t_ptr();
 
     }
 
@@ -35,9 +35,9 @@ public class SearchBase extends Pending
             hyperclient_attribute attrs = null;
             long attrs_sz = 0;
 
-            attrs = hyperclient.hyperclient_attribute_ptr_value(attrs_ptr);
+            attrs = hyperclient_lc.hyperclient_attribute_ptr_value(attrs_ptr);
 
-            attrs_sz = hyperclient.size_t_ptr_value(attrs_sz_ptr);
+            attrs_sz = hyperclient_lc.size_t_ptr_value(attrs_sz_ptr);
             try
             {
                 attrsMap =  client.attrs_to_dict(attrs,attrs_sz);
@@ -50,7 +50,7 @@ public class SearchBase extends Pending
             {
                 if ( attrs != null )
                 {
-                    hyperclient.hyperclient_destroy_attrs(attrs,attrs_sz);
+                    hyperclient_lc.hyperclient_destroy_attrs(attrs,attrs_sz);
                 }
             }
 
@@ -108,7 +108,7 @@ public class SearchBase extends Pending
     {
         super.finalize();
 
-        if (attrs_ptr != null) hyperclient.delete_hyperclient_attribute_ptr(attrs_ptr);
-        if (attrs_sz_ptr != null) hyperclient.delete_size_t_ptr(attrs_sz_ptr);
+        if (attrs_ptr != null) hyperclient_lc.delete_hyperclient_attribute_ptr(attrs_ptr);
+        if (attrs_sz_ptr != null) hyperclient_lc.delete_size_t_ptr(attrs_sz_ptr);
     }
 }

--- a/client/java/hyperclient.i
+++ b/client/java/hyperclient.i
@@ -26,7 +26,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-%module hyperclient
+%module hyperclient_lc
 
 %include "std_string.i"
 %include "stdint.i"

--- a/client/java/proxies/HyperClient.i
+++ b/client/java/proxies/HyperClient.i
@@ -301,13 +301,13 @@
 
   void loop() throws HyperClientException
   {
-    SWIGTYPE_p_hyperclient_returncode rc_ptr = hyperclient.new_rc_ptr();
+    SWIGTYPE_p_hyperclient_returncode rc_ptr = hyperclient_lc.new_rc_ptr();
 
     long ret = loop(-1, rc_ptr);
 
-    hyperclient_returncode rc = hyperclient.rc_ptr_value(rc_ptr);
+    hyperclient_returncode rc = hyperclient_lc.rc_ptr_value(rc_ptr);
 
-    hyperclient.delete_rc_ptr(rc_ptr); // Deallocate the pointer
+    hyperclient_lc.delete_rc_ptr(rc_ptr); // Deallocate the pointer
 
     if ( ret < 0 )
     {


### PR DESCRIPTION
OS X based machines ship with a case-insensitve file system.
Swig generates two java source files hyperclient.java (specified
by the %module directive) and HyperClient.java which is the publicly
visible java client object. I simply renamed the internal one to
avoid the conflict.

Signed-off-by: Nick Tolomiczenko nick.tolomiczenko@gmail.com
