### PR TITLE
Monkey Patches for Macosx builds

### DIFF
--- a/admin/pending_perf_counters.cc
+++ b/admin/pending_perf_counters.cc
@@ -34,6 +34,23 @@
 
 using hyperdex::pending_perf_counters;
 
+#ifdef __MACH__
+#include <mach/clock.h>
+#include <mach/mach.h>
+#define CLOCK_REALTIME 0x01
+#define CLOCK_MONOTONIC 0x02
+int clock_gettime(int ign, struct timespec * ts){
+	clock_serv_t cclock;
+	mach_timespec_t mts;
+	host_get_clock_service(mach_host_self(), CALENDAR_CLOCK, &cclock);
+	clock_get_time(cclock, &mts);
+	mach_port_deallocate(mach_task_self(), cclock);
+	ts->tv_sec = mts.tv_sec;
+	ts->tv_nsec = mts.tv_nsec;
+	return 1;
+}
+#endif
+
 static uint64_t
 monotonic_time()
 {

--- a/admin/pending_perf_counters.h
+++ b/admin/pending_perf_counters.h
@@ -34,6 +34,7 @@
 // HyperDex
 #include "admin/pending.h"
 
+
 BEGIN_HYPERDEX_NAMESPACE
 
 class pending_perf_counters : public pending


### PR DESCRIPTION
1) Monkey patch for Macosx build required on perf_counters
2) Processor affinity set on Macosx
3) std::min template error
