### PR TITLE
updating Ubuntu installation to use the correct dist

### DIFF
--- a/doc/02.installation.rst
+++ b/doc/02.installation.rst
@@ -48,7 +48,7 @@ Ubuntu
 To access the Ubuntu repository, add the following to
 ``/etc/apt/sources.list``::
 
-   deb [arch=amd64] http://ubuntu.hyperdex.org oneiric main
+   deb [arch=amd64] http://ubuntu.hyperdex.org precise main
 
 Subsequent invocations of the package manager may complain about the absence of
 the relevant package signing key.  You can download the `Ubuntu public key`_ and


### PR DESCRIPTION
Noticed the ubuntu dist was wrong in the installation instructions but it's fine in your `hyperdex.list` 
