### PR TITLE
use importers GOMAXPROCS instead of NumCPU() for # clients

### DIFF
--- a/bindings/go/client/client.go
+++ b/bindings/go/client/client.go
@@ -1068,7 +1068,7 @@ func (client *innerClient) runForever(errChan chan Error) {
 }
 
 func NewClient(host string, port int) (*Client, error, chan Error) {
-	numClients := runtime.NumCPU()
+	numClients := runtime.GOMAXPROCS(-1) // use client app's current settings, -1 will not mutate
 	clients := make([]*innerClient, 0, numClients)
 	for i := 0; i < numClients; i++ {
 		C_client := C.hyperdex_client_create(C.CString(host), C.uint16_t(port))


### PR DESCRIPTION
clients may explicitly set GOMAXPROCS and expect such behavior, for importers that already set GOMAXPROCS to NumCPU() this change will not have an effect. 
