### PR TITLE
Fixing go docs to reflect change in error handling.

### DIFF
--- a/doc/go/client.tex
+++ b/doc/go/client.tex
@@ -160,7 +160,7 @@ client.Predicate{"attr", "needle", client.CONTAINS}
 \label{sec:api:go-client:error-handling}
 
 All error handling within the Go bindings is done via \code{client.Error}
-returned from each operation.  An error object will always be returned, and its
+returned from each operation.  If an error object is returned, its
 status should be checked following the call.  For example, we may conditionally
 change the value of \code{v} from \code{"foo"} to \code{"bar"} like this:
 
@@ -168,7 +168,7 @@ change the value of \code{v} from \code{"foo"} to \code{"bar"} like this:
 err := client.CondPut("kv", "some key",
         []client.Predicate{{"v", "foo", client.EQUALS}},
         client.Attributes{"v": "bar"})
-if err.Status == client.SUCCESS {
+if err != nil {
     // it worked
 } else if err.Status == client.CMPFAIL {
     // the existing value was not "foo"

--- a/doc/go/client/hello-world.go
+++ b/doc/go/client/hello-world.go
@@ -18,12 +18,12 @@ func main() {
 	}()
 	// do the operations
 	err := c.Put("kv", "some key", client.Attributes{"v": "Hello World!"})
-	if err.Status != client.SUCCESS {
+	if err != nil {
 		// handle the error here
 	}
 	fmt.Println("put: \"Hello World!\"")
 	obj, err := c.Get("kv", "some key")
-	if err.Status != client.SUCCESS {
+	if err != nil {
 		// handle the error here
 	}
 	fmt.Println("got:", obj)


### PR DESCRIPTION
Error handling was changed to idiomatic go fashion (https://github.com/rescrv/HyperDex/pull/187), but the documentation and example code was not changed.